### PR TITLE
add bin/rails assets:precompile on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ http://localhost:3000/ にアクセス
 
 ```bash
 docker compose build
+docker compose run --rm web bin/rails assets:precompile
 docker compose up
 ```
 


### PR DESCRIPTION
Hi!

I read [WEB+DB PRESS Vol.130](https://gihyo.jp/magazine/wdpress/archive/2022/vol130).
Very cool article, thank you very much.

I use Docker.

- git clone https://github.com/kurotaky/sample-rails-dapp.git
- cd sample-rails-dapp
- docker compose build
- docker compose up
- Visit: http://0.0.0.0:3000/nfts

Web has the error.

```
ActionView::Template::Error (The asset "tailwind.css" is not present in the asset pipeline.)
```

There is no `/myapp/public/assets`.
So, I did `docker compose run --rm web bin/rails assets:precompile` .
Good.

This pullrequest suggests to add the command in README.
I think a change in Dockerfile or docker-compose.yml may be better.

Hope this helps.